### PR TITLE
Mptcp@adress

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -1341,6 +1341,7 @@ The following keywords are supported in the "global" section :
    - maxsslconn
    - maxsslrate
    - maxzlibmem
+   - mptcp
    - no-memory-trimming
    - noepoll
    - noevports
@@ -2957,6 +2958,14 @@ maxzlibmem <number>
   The default value is 0. The value is available in bytes on the UNIX socket
   with "show info" on the line "MaxZlibMemUsage", the memory used by zlib is
   "ZlibMemUsage" in bytes.
+
+mptcp
+  Uses MPTCP instead of TCP. Multipath TCP or MPTCP is an extension to the
+  standard TCP and is described in RFC 8684. It allows a device to make use of
+  multiple interfaces at once to send and receive TCP packets over a single
+  MPTCP connection. MPTCP can aggregate the bandwidth of multiple interfaces or
+  prefer the one with the lowest latency, it also allows a fail-over if one path
+  is down, and the traffic is seamlessly reinjected on other paths.
 
 no-memory-trimming
   Disables memory trimming ("malloc_trim") at a few moments where attempts are

--- a/include/haproxy/proto_rhttp.h
+++ b/include/haproxy/proto_rhttp.h
@@ -5,6 +5,8 @@
 #include <haproxy/listener-t.h>
 #include <haproxy/receiver-t.h>
 
+extern struct protocol proto_rhttp;
+
 int rhttp_bind_receiver(struct receiver *rx, char **errmsg);
 
 int rhttp_bind_listener(struct listener *listener, char *errmsg, int errlen);

--- a/src/cfgparse-global.c
+++ b/src/cfgparse-global.c
@@ -1343,9 +1343,10 @@ int cfg_parse_global(const char *file, int linenum, char **args, int kwm)
 #ifndef IPPROTO_MPTCP
 #define IPPROTO_MPTCP 262
 #endif
-		proto_tcpv4.sock_prot = IPPROTO_MPTCP;
-		proto_tcpv6.sock_prot = IPPROTO_MPTCP;
-		proto_rhttp.sock_prot = IPPROTO_MPTCP;
+		// TODO:
+		// proto_tcpv4.sock_prot = IPPROTO_MPTCP;
+		// proto_tcpv6.sock_prot = IPPROTO_MPTCP;
+		// proto_rhttp.sock_prot = IPPROTO_MPTCP;
 #else
 		ha_alert("parsing [%s:%d]: '%s' is only supported on Linux.\n",
 			 file, linenum, args[0]);

--- a/src/cfgparse-global.c
+++ b/src/cfgparse-global.c
@@ -23,6 +23,8 @@
 #include <haproxy/log.h>
 #include <haproxy/peers.h>
 #include <haproxy/protocol.h>
+#include <haproxy/proto_rhttp.h>
+#include <haproxy/proto_tcp.h>
 #include <haproxy/tools.h>
 
 int cluster_secret_isset;
@@ -52,7 +54,7 @@ static const char *common_kw_list[] = {
 	"presetenv", "unsetenv", "resetenv", "strict-limits", "localpeer",
 	"numa-cpu-mapping", "defaults", "listen", "frontend", "backend",
 	"peers", "resolvers", "cluster-secret", "no-quic", "limited-quic",
-	NULL /* must be last */
+	"mptcp", NULL /* must be last */
 };
 
 /*
@@ -1333,6 +1335,23 @@ int cfg_parse_global(const char *file, int linenum, char **args, int kwm)
 
 			HA_ATOMIC_STORE(&global.anon_key, tmp);
 		}
+	}
+	else if (strcmp(args[0], "mptcp") == 0) {
+		if (alertif_too_many_args(0, file, linenum, args, &err_code))
+			goto out;
+#ifdef __linux__
+#ifndef IPPROTO_MPTCP
+#define IPPROTO_MPTCP 262
+#endif
+		proto_tcpv4.sock_prot = IPPROTO_MPTCP;
+		proto_tcpv6.sock_prot = IPPROTO_MPTCP;
+		proto_rhttp.sock_prot = IPPROTO_MPTCP;
+#else
+		ha_alert("parsing [%s:%d]: '%s' is only supported on Linux.\n",
+			 file, linenum, args[0]);
+		err_code |= ERR_ALERT | ERR_FATAL;
+		goto out;
+#endif
 	}
 	else {
 		struct cfg_kw_list *kwl;

--- a/src/cfgparse-global.c
+++ b/src/cfgparse-global.c
@@ -23,6 +23,8 @@
 #include <haproxy/log.h>
 #include <haproxy/peers.h>
 #include <haproxy/protocol.h>
+#include <haproxy/proto_rhttp.h>
+#include <haproxy/proto_tcp.h>
 #include <haproxy/tools.h>
 
 int cluster_secret_isset;
@@ -52,7 +54,7 @@ static const char *common_kw_list[] = {
 	"presetenv", "unsetenv", "resetenv", "strict-limits", "localpeer",
 	"numa-cpu-mapping", "defaults", "listen", "frontend", "backend",
 	"peers", "resolvers", "cluster-secret", "no-quic", "limited-quic",
-	NULL /* must be last */
+	"mptcp", NULL /* must be last */
 };
 
 /*
@@ -1333,6 +1335,24 @@ int cfg_parse_global(const char *file, int linenum, char **args, int kwm)
 
 			HA_ATOMIC_STORE(&global.anon_key, tmp);
 		}
+	}
+	else if (strcmp(args[0], "mptcp") == 0) {
+		if (alertif_too_many_args(0, file, linenum, args, &err_code))
+			goto out;
+#ifdef __linux__
+#ifndef IPPROTO_MPTCP
+#define IPPROTO_MPTCP 262
+#endif
+		// TODO:
+		// proto_tcpv4.sock_prot = IPPROTO_MPTCP;
+		// proto_tcpv6.sock_prot = IPPROTO_MPTCP;
+		// proto_rhttp.sock_prot = IPPROTO_MPTCP;
+#else
+		ha_alert("parsing [%s:%d]: '%s' is only supported on Linux.\n",
+			 file, linenum, args[0]);
+		err_code |= ERR_ALERT | ERR_FATAL;
+		goto out;
+#endif
 	}
 	else {
 		struct cfg_kw_list *kwl;

--- a/src/cfgparse-listen.c
+++ b/src/cfgparse-listen.c
@@ -200,7 +200,10 @@ int warnif_misplaced_tcp_conn(struct proxy *proxy, const char *file, int line, c
 }
 
 int cfg_parse_listen(const char *file, int linenum, char **args, int kwm)
-{
+{	
+	printf("je suis dans cfg_parse_listen\n");
+
+
 	static struct proxy *curr_defproxy = NULL;
 	static struct proxy *last_defproxy = NULL;
 	const char *err;
@@ -490,6 +493,7 @@ int cfg_parse_listen(const char *file, int linenum, char **args, int kwm)
 		 * are comma-separated IPs or port ranges. So all further processing
 		 * will have to be applied to all listeners created after last_listen.
 		 */
+		printf("je passe par laaa $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$\n");
 		if (!str2listener(args[1], curproxy, bind_conf, file, linenum, &errmsg)) {
 			if (errmsg && *errmsg) {
 				indent_msg(&errmsg, 2);

--- a/src/cfgparse.c
+++ b/src/cfgparse.c
@@ -77,6 +77,7 @@
 #include <haproxy/peers.h>
 #include <haproxy/pool.h>
 #include <haproxy/protocol.h>
+#include <haproxy/proto_tcp.h>
 #include <haproxy/proxy.h>
 #include <haproxy/resolvers.h>
 #include <haproxy/sample.h>
@@ -1193,7 +1194,7 @@ int cfg_parse_mailers(const char *file, int linenum, char **args, int kwm)
 			goto out;
 		}
 
-		if (proto->sock_prot != IPPROTO_TCP) {
+		if (proto->sock_prot != proto_tcpv4.sock_prot) {
 			ha_alert("parsing [%s:%d] : '%s %s' : TCP not supported for this address family.\n",
 				 file, linenum, args[0], args[1]);
 			err_code |= ERR_ALERT | ERR_FATAL;

--- a/src/cfgparse.c
+++ b/src/cfgparse.c
@@ -128,6 +128,22 @@ struct cfg_kw_list cfg_keywords = {
 	.list = LIST_HEAD_INIT(cfg_keywords.list)
 };
 
+
+/* Ajoute "tcp4@" au début de l'adresse IP si elle est présente */
+char *tcp4_prefix(char *addr) {
+    static const char prefix[] = "mptcp4@";
+    if (addr && strncmp(addr, "mptcp4@", strlen(prefix)) != 0) {
+        size_t new_len = strlen(addr) + strlen(prefix) + 1;
+        char *prefixed_addr = malloc(new_len);
+        if (prefixed_addr) {
+            strcpy(prefixed_addr, prefix);
+            strcat(prefixed_addr, addr);
+            return prefixed_addr;
+        }
+    }
+    return addr;
+}
+
 /*
  * converts <str> to a list of listeners which are dynamically allocated.
  * The format is "{addr|'*'}:port[-end][,{addr|'*'}:port[-end]]*", where :
@@ -157,10 +173,12 @@ int str2listener(char *str, struct proxy *curproxy, struct bind_conf *bind_conf,
 			*next++ = 0;
 		}
 
-		ss2 = str2sa_range(str, NULL, &port, &end, &fd, &proto, NULL, err,
+	
+		ss2 = str2sa_range(tcp4_prefix(str), NULL, &port, &end, &fd, &proto, NULL, err,
 		                   (curproxy == global.cli_fe || curproxy == mworker_proxy) ? NULL : global.unix_bind.prefix,
 		                   NULL, PA_O_RESOLVE | PA_O_PORT_OK | PA_O_PORT_MAND | PA_O_PORT_RANGE |
 		                          PA_O_SOCKET_FD | PA_O_STREAM | PA_O_XPRT);
+		printf("je passe ici !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
 		if (!ss2)
 			goto fail;
 
@@ -705,7 +723,7 @@ int cfg_parse_peers(const char *file, int linenum, char **args, int kwm)
 				ha_alert("parsing [%s:%d] : One listener per \"peers\" section is authorized but another is already configured at [%s:%d].\n", file, linenum, bind_conf->file, bind_conf->line);
 				err_code |= ERR_FATAL;
 			}
-
+			printf("je passe ici ùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùùù\n");
 			if (!str2listener(args[1], curpeers->peers_fe, bind_conf, file, linenum, &errmsg)) {
 				if (errmsg && *errmsg) {
 					indent_msg(&errmsg, 2);
@@ -1739,6 +1757,7 @@ static int cfg_parse_global_def_path(char **args, int section_type, struct proxy
  */
 int readcfgfile(const char *file)
 {
+	// TODO: 
 	char *thisline = NULL;
 	int linesize = LINESIZE;
 	FILE *f = NULL;

--- a/src/tools.c
+++ b/src/tools.c
@@ -972,12 +972,16 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 	int new_fd = -1;
 	enum proto_type proto_type = 0; // to shut gcc warning
 	int ctrl_type = 0; // to shut gcc warning
+	int mptcp = 0;
 
 	portl = porth = porta = 0;
 	if (fqdn)
 		*fqdn = NULL;
 
+	printf("str = %s\n", str);
 	str2 = back = env_expand(strdup(str));
+
+	printf("str2 = %s\n", str2);
 	if (str2 == NULL) {
 		memprintf(err, "out of memory in '%s'", __FUNCTION__);
 		goto out;
@@ -1057,6 +1061,17 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 		ss.ss_family = AF_INET;
 		proto_type = PROTO_TYPE_STREAM;
 		ctrl_type = SOCK_STREAM;
+
+		printf(" DANS TCP4@ \n");
+	}
+	else if (strncmp(str2, "mptcp4@", 7) == 0) {
+		str2 += 7;
+		ss.ss_family = AF_INET;
+		proto_type = PROTO_TYPE_STREAM;
+		ctrl_type = SOCK_STREAM;
+		// TODO:
+		mptcp = 1;
+		printf(" DANS MPTCP4@ \n");
 	}
 	else if (strncmp(str2, "udp4@", 5) == 0) {
 		str2 += 5;
@@ -1069,6 +1084,16 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 		ss.ss_family = AF_INET6;
 		proto_type = PROTO_TYPE_STREAM;
 		ctrl_type = SOCK_STREAM;
+		printf(" DANS TCP6@ \n");
+	}
+	else if (strncmp(str2, "mptcp6@", 7) == 0) {
+		str2 += 7;
+		ss.ss_family = AF_INET;
+		proto_type = PROTO_TYPE_STREAM;
+		ctrl_type = SOCK_STREAM;
+		// TODO:
+		mptcp = 1;
+		printf(" DANS MPTCP6@ \n");
 	}
 	else if (strncmp(str2, "udp6@", 5) == 0) {
 		str2 += 5;
@@ -1387,6 +1412,12 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 
 	ret = &ss;
  out:
+	if (mptcp)
+#ifndef IPPROTO_MPTCP
+#define IPPROTO_MPTCP 262
+#endif
+// TODO:
+		new_proto->sock_prot = IPPROTO_MPTCP;
 	if (port)
 		*port = porta;
 	if (low)


### PR DESCRIPTION
Multipath TCP (MPTCP), standardized in RFC8684 [1], is a TCP extension
that enables a TCP connection to use different paths.

Multipath TCP has been used for several use cases. On smartphones, MPTCP
enables seamless handovers between cellular and Wi-Fi networks while
preserving established connections. This use-case is what pushed Apple
to use MPTCP since 2013 in multiple applications [2]. On dual-stack
hosts, Multipath TCP enables the TCP connection to automatically use the
best performing path, either IPv4 or IPv6. If one path fails, MPTCP
automatically uses the other path.

To benefit from MPTCP, both the client and the server have to support
it. Multipath TCP is a backward-compatible TCP extension that is enabled
by default on recent Linux distributions (Debian, Ubuntu, Redhat, ...).
Multipath TCP is included in the Linux kernel since version 5.6 [3]. To
use it on Linux, an application must explicitly enable it when creating
the socket. No need to change anything else in the application.

This attached patch adds an mptcp option in the config which allows the
creation of an MPTCP socket instead of TCP on Linux. If Multipath TCP
is not supported on the system, an error will be reported and the start failed.

Due to the limited impact within a data center environment,
we have decided not to implement MPTCP between the proxy and the servers.
The high-speed, low-latency nature of data center networks reduces
the benefits of MPTCP, making the complexity of its implementation
unnecessary in this context.

Developed with the help of Matthieu Baerts (matttbe@kernel.org) and
Olivier Bonaventure (Olivier.Bonaventure@uclouvain.be)

Link: https://www.rfc-editor.org/rfc/rfc8684.html [1]
Link: https://www.tessares.net/apples-mptcp-story-so-far/ [2]
Link: https://www.mptcp.dev [3]